### PR TITLE
Fix multiple state counties

### DIFF
--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -75,6 +75,9 @@ function createStateDropdown(data_loc) {
     stateLabel.innerHTML = "State"
     newSelectState.setAttribute("id", `stateSelect_${numSelectors}`);
     newSelectState.setAttribute("class", "stateSelectors");
+    
+    jQuery("#countySelect").empty();
+
     newSelectState.setAttribute("onchange",
         onchange=`if (this.selectedIndex) changeCounties(this.options[this.selectedIndex].text, 'countySelect_${numSelectors}', '${data_loc}')`);
     newSelectState.innerHTML = "<option value='--'>--</option>";

--- a/website/static/js/main.js
+++ b/website/static/js/main.js
@@ -43,9 +43,19 @@ function generateView() {
     }
 }
 
+function removeAll(selectBox) {
+    while (selectBox.options.length > 0) {
+        selectBox.remove(0);
+    }
+}
+
 function changeCounties(state, id, loc) {
   jQuery.getJSON(loc, function(json) {
     var selector = document.querySelector(`select[id="${id}"]`)
+
+    //remove all counties currently in the
+    //drop down select box
+    removeAll(selector);
 
     jQuery("#countySelect").empty();
 
@@ -75,9 +85,6 @@ function createStateDropdown(data_loc) {
     stateLabel.innerHTML = "State"
     newSelectState.setAttribute("id", `stateSelect_${numSelectors}`);
     newSelectState.setAttribute("class", "stateSelectors");
-    
-    jQuery("#countySelect").empty();
-
     newSelectState.setAttribute("onchange",
         onchange=`if (this.selectedIndex) changeCounties(this.options[this.selectedIndex].text, 'countySelect_${numSelectors}', '${data_loc}')`);
     newSelectState.innerHTML = "<option value='--'>--</option>";


### PR DESCRIPTION
Fixed the issue where the county drop down menu would become congested with multiple states' counties if a user selected multiple different states without refreshing/generating a view

Fixed it by calling a function that programmatically removes every optionfrom the drop down menu before re-populating it